### PR TITLE
Folder upload

### DIFF
--- a/downloader/tests/test_repo_download.py
+++ b/downloader/tests/test_repo_download.py
@@ -1,15 +1,22 @@
 import os
 import urllib
 
+import pytest
 from django.urls import reverse
 
 
-def test_repository_downloader_integration(client):
-    url = reverse("download_repo")
-    test_repo_url = "https://github.com/dmwyatt/gh_repo_dl_test"
+@pytest.fixture
+def expected_content():
     expected_content_file = os.path.join(
         os.path.dirname(__file__), "data", "gh_repo_dl_test.txt"
     )
+    with open(expected_content_file, "r") as f:
+        return f.read()
+
+
+def test_repository_downloader_integration(client, expected_content):
+    url = reverse("download_repo")
+    test_repo_url = "https://github.com/dmwyatt/gh_repo_dl_test"
 
     # Send a POST request to the view with the test repository URL
     response = client.post(url, {"repo_url": test_repo_url}, follow=True)
@@ -29,10 +36,6 @@ def test_repository_downloader_integration(client):
 
     # Decode the URL-encoded content
     decoded_content = urllib.parse.unquote(data_uri)
-
-    # Read the expected content from the file
-    with open(expected_content_file, "r") as file:
-        expected_content = file.read()
 
     # Compare the decoded content with the expected content
     assert decoded_content == expected_content

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "fflate": "^0.8.2",
+        "ignore": "^5.3.1",
         "tiktoken": "^1.0.13",
         "vite": "^5.1.6"
       },
@@ -804,6 +805,14 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
+      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/nanoid": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "fflate": "^0.8.2",
+    "ignore": "^5.3.1",
     "tiktoken": "^1.0.13",
     "vite": "^5.1.6"
   },

--- a/templates/downloader.html
+++ b/templates/downloader.html
@@ -59,11 +59,21 @@
           border-radius: 4px;
           box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1); /* Soft shadow for depth */
       }
-      
+
       button {
           max-width: 250px
       }
 
+      #manualGitignore {
+          min-height: 100px;
+          max-height: 300px;
+          overflow-y: auto;
+      }
+
+      .instructions {
+          font-size: 14px;
+          margin-bottom: 5px;
+      }
 
   </style>
 {% endblock %}
@@ -98,6 +108,7 @@
       {% endif %}
 
       <div class="forms">
+
         <form method="post">
           {% csrf_token %}
           {{ repo_url_form.repo_url.label }}
@@ -108,10 +119,9 @@
             </div>
           {% endif %}
           <button type="submit" style="margin-top: 10px">Submit</button>
-        <button id="fillFormButton" type="button">Test it out with this site's repo!
-        
+          <button id="fillFormButton" type="button">Test it out with this site's repo!
+          </button>
         </form>
-        </button>
 
         {% if zip_file_form.non_field_errors %}
           {% for error in zip_file_form.non_field_errors %}
@@ -136,6 +146,50 @@
                class="error-message-def-hidden"
                style="display:none;"></div>
           <button type="submit" style="margin-top: 10px">Submit</button>
+        </form>
+
+        <form id="folderForm">
+          <div>
+            <label for="folderInput">Select Folder:</label>
+            <input type="file" id="folderInput" webkitdirectory directory/>
+          </div>
+
+          <div>
+            <p class="instructions">
+              Enter additional .gitignore rules to exclude specific files or directories
+              from the selected folder. Each rule should be on a separate line.
+            </p>
+            <textarea id="manualGitignore" name="manual_gitignore">
+node_modules/
+.venv/
+venv/
+.git/
+.idea/
+*.log
+*.pyc
+*.swp
+dist/
+build/
+coverage/
+*.o
+*.a
+*.so
+*.bin
+*.exe
+*.dll
+.env
+.env.*
+.vscode/
+.sublime-project
+.sublime-workspace
+.DS_Store
+Thumbs.db
+*~
+*.bak
+          </textarea>
+          </div>
+
+          <button type="submit">Submit Folder</button>
         </form>
 
       </div>


### PR DESCRIPTION
Upload folders.  

The project now offers three options:

1. Processes a GitHub repo by its url
2. Processes an uploaded ZIP
3. Processes a folder from the user's device.

Not that we leverage existing functionality by using `fflate` to ZIP up the folder on the users device and then just handle it like we already handled ZIP files.